### PR TITLE
Change default [CMD] to work from volumes and update version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:14-jdk-alpine3.10
 MAINTAINER think@hotmail.de
-ENV PLANTUML_VERSION=1.2020.9
+ENV PLANTUML_VERSION=1.2020.19
 ENV LANG en_US.UTF-8
 RUN \
   apk add --no-cache graphviz wget ca-certificates && \
@@ -9,5 +9,5 @@ RUN \
   apk del wget ca-certificates
 RUN ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar", "-version"]
 RUN ["dot", "-version"]
-ENTRYPOINT ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar", "-p"]
-CMD ["-tsvg"]
+ENTRYPOINT ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar"]
+CMD ["-tsvg", "-pipe"]


### PR DESCRIPTION
Moved `-pipe`  option to CMD so container can be used to read and write from filesystem (e.g. using bind mounts).

NOTE: Default behaviour has not changed.

To use new feature, for example in a makefile

```
	docker container run -v $(CURDIR):/data --rm -i docker_plantuml -tpng  -o /data/$(@D) /data/$<
```

