### PR TITLE
Use build-args to specify system, version, locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM openjdk:14-jdk-alpine3.10
+ARG JDK_VERSION=14-jdk-alpine3.10
+FROM openjdk:${JDK_VERSION}
 MAINTAINER think@hotmail.de
-ENV PLANTUML_VERSION=1.2020.9
-ENV LANG en_US.UTF-8
+ARG PLANTUML_VERSION_BUILD=1.2020.9
+ARG LOCALE_BUILD=en_US.UTF-8
+ENV PLANTUML_VERSION=${PLANTUML_VERSION_BUILD}
+ENV LANG ${LOCALE_BUILD}
 RUN \
   apk add --no-cache graphviz wget ca-certificates && \
   apk add --no-cache graphviz wget ca-certificates ttf-dejavu fontconfig && \
-  wget "http://downloads.sourceforge.net/project/plantuml/${PLANTUML_VERSION}/plantuml.${PLANTUML_VERSION}.jar" -O plantuml.jar && \
+  wget "http://downloads.sourceforge.net/project/plantuml/${PLANTUML_VERSION_BUILD}/plantuml.${PLANTUML_VERSION_BUILD}.jar" -O plantuml.jar && \
   apk del wget ca-certificates
 RUN ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar", "-version"]
 RUN ["dot", "-version"]


### PR DESCRIPTION
This proposes several small changes. They may or may not benefit the original developer, but they would side-step the "Version bump" PR's

1. Make Java Docker-base a build-argument with default value.
  * keeps as-is (defaults).
  * enables upstream changes without conflict resolution or tiny commits.
2. Enables changing PlantUML version by rebuilding the docker image.
3. Makes locale a build-time argument.
  * It's UTF-8 so should not be an issue, but gives those who care the option.

Thanks for making this.