### PR TITLE
Upgrade to plantuml 1 2021 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:14-jdk-alpine3.10
 MAINTAINER think@hotmail.de
-ENV PLANTUML_VERSION=1.2020.9
+ENV PLANTUML_VERSION=1.2021.9
 ENV LANG en_US.UTF-8
 RUN \
   apk add --no-cache graphviz wget ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:14-jdk-alpine3.10
 MAINTAINER think@hotmail.de
-ENV PLANTUML_VERSION=1.2021.9
+ENV PLANTUML_VERSION=1.2021.13
 ENV LANG en_US.UTF-8
 RUN \
   apk add --no-cache graphviz wget ca-certificates && \


### PR DESCRIPTION
In order to support using C4-PlantUML, which is included in PlantUML Stdlib
I would like have an up to date version of PlantUML available in the Docker images.

Closes #19 