### PR TITLE
Replace deprecated instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:19-jdk-alpine3.16
-MAINTAINER think@hotmail.de
+LABEL org.opencontainers.image.authors="think@hotmail.de"
 ENV PLANTUML_VERSION=1.2023.1
 ENV LANG en_US.UTF-8
 RUN \


### PR DESCRIPTION
- `MAINTAINER` instruction is deprecated.
  https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
- Used `LABEL org.opencontainers.image.authors="..."` instead.
- `org.opencontainers.image.authors` is one of OCI Pre-Defined Annotation Keys.
  https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys